### PR TITLE
Ustalenie nazwy klienta MQTT na podstawie nazwy urządzenia

### DIFF
--- a/Smogomierz.ino
+++ b/Smogomierz.ino
@@ -295,6 +295,7 @@ PMS::DATA data;
 // DUST Sensor config - END
 
 char device_name[20];
+char mqqt_id[20];
 
 unsigned int DUST_interval = 60 * 1000; // 1 minute
 unsigned int previous_DUST_Millis = 0;
@@ -448,7 +449,7 @@ void MQTTreconnect() {
   if (!mqttclient.connected()) {
     Serial.print(F("Attempting MQTT connection..."));
     // Attempt to connect
-    if (mqttclient.connect("ESP8266Client", MQTT_USER, MQTT_PASSWORD)) {
+    if (mqttclient.connect(mqqt_id, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println(F("connected"));
     } else {
       Serial.print(F("failed, rc="));
@@ -860,6 +861,8 @@ void setup() {
   } else {
     strncpy(device_name, DEVICENAME, 20);
   }
+  
+  strcpy(mqqt_id, device_name);
 
   Serial.print(F("Device name: "));
   Serial.println(device_name);


### PR DESCRIPTION
Do tej pory w kodzie nazwą klienta było: ESP8266Client. Do serwera MQTT nie mogą być połączeni dwaj klienci o tym samym ID.
Gdy ktoś w sieci ma urządzenie, którego oprogramowanie było tworzone na podstawie przykładów, jest duża szansa, że podłącza się ono do serwera MQTT z podanym wyżej identyfikatorem.
Serwer MQTT nie pozwoli przekazywać tematów drugiemu urządzeniu z zduplikowaną nazwą. Jednak PubSubClient podczas połączenia nie zgłasza błedu. Wygląda, że wszystko się udało.

Moja poprawka uzależnia nazwę serwera MQTT od nazwy urządzenia smogomierza.